### PR TITLE
Fix deprecated way of importing MutableMapping

### DIFF
--- a/diagnnose/utils/misc.py
+++ b/diagnnose/utils/misc.py
@@ -2,7 +2,7 @@ import contextlib
 import cProfile
 import io
 import pstats
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from functools import wraps
 from typing import Any, Callable, Dict
 


### PR DESCRIPTION
`from collections import MutableMapping` is deprecated and in 3.10 it has to be `from collections.abc import MutableMapping`
See also: https://stackoverflow.com/a/70870087